### PR TITLE
Working around heap corruption in the latest premake.

### DIFF
--- a/export-compile-commands.lua
+++ b/export-compile-commands.lua
@@ -52,7 +52,7 @@ end
 function m.generateCompileCommand(prj, cfg, node)
   return {
     directory = prj.location,
-    file = node.abspath, 
+    file = node.abspath,
     command = 'cc '.. table.concat(m.getFileFlags(prj, cfg, node), ' ')
   }
 end
@@ -101,10 +101,10 @@ local function execute()
     for cfgKey,cmds in pairs(cfgCmds) do
       local outfile = string.format('compile_commands/%s.json', cfgKey)
       p.generate(wks, outfile, function(wks)
-        local jsonCmds = {}
+        p.w('[')
         for i = 1, #cmds do
           local item = cmds[i]
-          table.insert(jsonCmds, string.format([[
+          local command = string.format([[
           {
             "directory": "%s",
             "file": "%s",
@@ -112,10 +112,12 @@ local function execute()
           }]],
           item.directory,
           item.file,
-          item.command:gsub('\\', '\\\\'):gsub('"', '\\"')))
+          item.command:gsub('\\', '\\\\'):gsub('"', '\\"'))
+          if i > 1 then
+            p.w(',')
+          end
+          p.w(command)
         end
-        p.w('[')
-        p.w(table.concat(jsonCmds, ',\n'))
         p.w(']')
       end)
     end


### PR DESCRIPTION
Sending too much data (like a mb of json) to p.w will trigger an overflow
in lua buffer code. This writes the file incrementally to work around that.
